### PR TITLE
BATIAI-1194 - Add variable for server-side encryption

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -91,7 +91,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "bucket" {
   rule {
     apply_server_side_encryption_by_default {
       kms_master_key_id = var.s3_bucket_kms_key_id
-      sse_algorithm     = "aws:kms"
+      sse_algorithm     = var.sse_algorithm
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -17,3 +17,9 @@ variable "s3_bucket_kms_key_id" {
   default     = null
   description = "KMS Key used to encrypt s3 buckets.  Defaults to null, which uses default aws/s3 key"
 }
+
+variable "sse_algorithm" {
+  type        = string
+  default     = "aws:kms"
+  description = "The server-side encryption algorithm to use. Valid values are AES256 and aws:kms, defaults to aws:kms."
+}


### PR DESCRIPTION
## Fixes Issue: [link to JIRA ticket](http://example.com)

## Description:

Adds variable for server-side encryption so that AES256 can be specified when ADOs request it instead of aws:kms.

## Security Impact Analysis Questionnaire
### Submitter Checklist
-  [ ] Is there an impact on Auditing and Logging procedures or capabilities?
-  [ ] Is there an impact on Authentication procedures or capabilities?
-  [ ] Is there an impact on Authorization procedures or capabilities?
-  [ ] Is there an impact on Communication Security procedures or capabilities?
-  [ ] Is there an impact on Cryptography procedures or capabilities?
-  [ ] Is there an impact on Sensitive Data procedures or capabilities?
-  [ ] Is there an impact on any other security-related procedures or capabilities?
-  [x] No security impacts identified.

Security Risks Identified - For any applicable items on the "Submitter Checklist," describe the impact of the change and any implemented mitigations.
