### PR TITLE
BATIAI-1543 - Fix bug with bucket module, set ownership to prevent ACLs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,10 +11,12 @@ locals {
   #buckets = { for bucket in aws_s3_bucket.landing_zone_buckets : bucket.id => bucket }
 }
 
-resource "aws_s3_bucket_acl" "landing_zone_buckets" {
+resource "aws_s3_bucket_ownership_controls" "landing_zone_buckets" {
   for_each = aws_s3_bucket.landing_zone_buckets
   bucket   = each.value.id
-  acl      = "private"
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
 }
 
 resource "aws_s3_bucket_public_access_block" "landing_zone_buckets" {


### PR DESCRIPTION


## Fixes Issue: [[link to JIRA ticket](https://jiraent.cms.gov/secure/RapidBoard.jspa?rapidView=4756&projectKey=BATIAI&view=detail&selectedIssue=BATIAI-1543)](http://example.com)

## Description:
Changed aws_s3_bucket_acl resource to be aws_s3_ownership_controls where object_ownership = "BucketOwnerEnforced". Fixed "The bucket does not allow ACLs." error when creating a cluster.

## Security Impact Analysis Questionnaire
### Submitter Checklist
-  [ ] Is there an impact on Auditing and Logging procedures or capabilities?
-  [ ] Is there an impact on Authentication procedures or capabilities?
-  [ ] Is there an impact on Authorization procedures or capabilities?
-  [ ] Is there an impact on Communication Security procedures or capabilities?
-  [ ] Is there an impact on Cryptography procedures or capabilities?
-  [ ] Is there an impact on Sensitive Data procedures or capabilities?
-  [ ] Is there an impact on any other security-related procedures or capabilities?
-  [x] No security impacts identified.

Security Risks Identified - For any applicable items on the "Submitter Checklist," describe the impact of the change and any implemented mitigations.
