### PR TITLE
BATIAI-1100 - Adding dynamic statements to bucket policy statements 

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -29,3 +29,10 @@ variable "lifecycle_expiration_days" {
   default     = "0"
   description = "Number of days for object lifecycle to expire the objects in dev env.  Defaults to 0, which disables the rule"
 }
+
+variable "additional_statements" {
+  type        = list(any)
+  default     = []
+  description = "List of additional bucket policy statements to apply to the buckets"
+}
+


### PR DESCRIPTION
Changed aws_s3_bucket_acl resource to be aws_s3_ownership_controls where object_ownership = "BucketOwnerEnforced". Fixed "The bucket does not allow ACLs." error when creating a cluster.

## Fixes Issue: [link to JIRA ticket](http://example.com)

## Description:


## Security Impact Analysis Questionnaire
### Submitter Checklist
-  [ ] Is there an impact on Auditing and Logging procedures or capabilities?
-  [ ] Is there an impact on Authentication procedures or capabilities?
-  [ ] Is there an impact on Authorization procedures or capabilities?
-  [ ] Is there an impact on Communication Security procedures or capabilities?
-  [ ] Is there an impact on Cryptography procedures or capabilities?
-  [ ] Is there an impact on Sensitive Data procedures or capabilities?
-  [ ] Is there an impact on any other security-related procedures or capabilities?
-  [ ] No security impacts identified.

Security Risks Identified - For any applicable items on the "Submitter Checklist," describe the impact of the change and any implemented mitigations.
